### PR TITLE
Remove ec2 instance exclusion in transcriber filter file

### DIFF
--- a/filter.yaml
+++ b/filter.yaml
@@ -3,4 +3,3 @@
 - include: aws-iam-instance-profiles:InstanceProfileName ~=
 - include: aws-iam-roles:RoleName ~=
 - include: "*:Tags[].Key == Migrate"
-- exclude: aws-ec2-instances:*


### PR DESCRIPTION
# Why

Transcriber automatically excludes EC2 instances that are part of an ASG.